### PR TITLE
add AES67 receiver packet counters

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ You must have a Core Status component in the design with script access enabled. 
 Available metrics may vary depending on Core model.  This has been tested on Nano, 110f, and 510i.
 Older versions of Qsys require _All_ access on the Status component, but _Script_ is sufficient on 9.8 and 9.9.
 
+If you want to include packet counters for AES67 and Atmos receivers, enable script access for those components too. (tested only on 9.9)
+
 Debug output logs the IP address of incoming requests if you are running version 9.8 or higher.
 
 Up to 20 additional metrics can be included by setting the `Custom Metrics` property.  This will expose input pins which can be wired to any numeric value.  If you don't enter labels, they will be omitted.  For percent type values, toggle the '%' button on; for other number types, leave it off.

--- a/example output.txt
+++ b/example output.txt
@@ -174,3 +174,29 @@ qsys_peripheral_status{invDeviceModel="AES67 Receiver",invDeviceName="AES67-RX-1
 qsys_peripheral_status{invDeviceModel="AES67 Receiver",invDeviceName="AES67-RX-2",invDeviceType="Streaming I/O",invLocation="IP Audio"} 1
 qsys_peripheral_status{invDeviceModel="TSC-80-G2",invDeviceName="TSC80-271e",invDeviceType="Control Interface",invLocation="TSC"} 3
 qsys_peripheral_status{invDeviceModel="I/O-8 Flex",invDeviceName="tuning-io-test",invDeviceType="Audio I/O",invLocation="Default Location"} 3
+# TYPE qsys_aes67_Enabled gauge
+# TYPE qsys_aes67_Connected_count gauge
+# TYPE qsys_aes67_DSCP gauge
+# TYPE qsys_aes67_count counter
+# TYPE qsys_aes67_accept_count counter
+# TYPE qsys_aes67_drop_count counter
+# TYPE qsys_aes67_missing_count counter
+# TYPE qsys_aes67_duplicate_count counter
+# TYPE qsys_aes67_ontime_count counter
+# TYPE qsys_aes67_late_count counter
+# TYPE qsys_aes67_pt_mismatch_count counter
+# TYPE qsys_aes67_size_mismatch_count counter
+qsys_aes67_Enabled{block="AES67_Receiver_AES67-RX-1"} 1
+qsys_aes67_Connected{block="AES67_Receiver_AES67-RX-1"} 0
+qsys_aes67_Enabled{block="AES67_Receiver_AES67-RX-2"} 1
+qsys_aes67_Connected{block="AES67_Receiver_AES67-RX-2"} 1
+qsys_aes67_DSCP{block="AES67_Receiver_AES67-RX-2"} 34
+qsys_aes67_count{block="AES67_Receiver_AES67-RX-2"} 23159
+qsys_aes67_accept_count{block="AES67_Receiver_AES67-RX-2"} 23159
+qsys_aes67_drop_count{block="AES67_Receiver_AES67-RX-2"} 0
+qsys_aes67_missing_count{block="AES67_Receiver_AES67-RX-2"} 83657
+qsys_aes67_duplicate_count{block="AES67_Receiver_AES67-RX-2"} 0
+qsys_aes67_ontime_count{block="AES67_Receiver_AES67-RX-2"} 23158
+qsys_aes67_late_count{block="AES67_Receiver_AES67-RX-2"} 0
+qsys_aes67_pt_mismatch_count{block="AES67_Receiver_AES67-RX-2"} 0
+qsys_aes67_size_mismatch_count{block="AES67_Receiver_AES67-RX-2"} 0

--- a/info.lua
+++ b/info.lua
@@ -1,7 +1,7 @@
 PluginInfo = {
   Name = "Prometheus Exporter",
-  Version = "1.4",
-  BuildVersion = "1.4.2.0",
+  Version = "1.5",
+  BuildVersion = "1.5.0.0",
   Id = "7d72a60b-48b7-4cf8-a498-6537aa0ff997",
   Author = "Elliott Balsley",
   Description = "Prometheus Exporter for Qsys Core metrics",

--- a/qsys-plugin-prometheus-exporter.qplug
+++ b/qsys-plugin-prometheus-exporter.qplug
@@ -4,8 +4,8 @@
 -- Information block for the plugin
 PluginInfo = {
   Name = "Prometheus Exporter",
-  Version = "1.4",
-  BuildVersion = "1.4.2.0",
+  Version = "1.5",
+  BuildVersion = "1.5.0.0",
   Id = "7d72a60b-48b7-4cf8-a498-6537aa0ff997",
   Author = "Elliott Balsley",
   Description = "Prometheus Exporter for Qsys Core metrics",
@@ -309,6 +309,42 @@ if Controls then
     end
   end
   
+  function GetStreamDetails(rx_name)
+    if DebugFunction then print("# Getting metrics from " .. rx_name) end
+    local rx = Component.New(rx_name)
+    local stream_details = rx['stream.details'].String
+  
+    local output = ''
+    for line in stream_details:gmatch("[^\r\n]+") do
+      for k,v in line:gmatch("(.*): (.*)") do
+        -- use the right type: gauge vs counter
+        if k == 'Enabled' or k == 'Connected' or k == 'DSCP' then
+          output = output .. 'qsys_aes67_' .. k .. '{' .. 'block="' .. rx_name .. '"} ' .. v .. '\n'
+        elseif k == 'Count' then
+          output = output .. 'qsys_aes67_count' ..  '{' .. 'block="' .. rx_name .. '"} ' .. v .. '\n'
+        elseif k == 'Accept Count' then
+          output = output .. 'qsys_aes67_accept_count' ..  '{' .. 'block="' .. rx_name .. '"} ' .. v .. '\n'
+        elseif k == 'Drop Count' then
+          output = output .. 'qsys_aes67_drop_count' ..  '{' .. 'block="' .. rx_name .. '"} ' .. v .. '\n'
+        elseif k == 'Missing Count' then
+          output = output .. 'qsys_aes67_missing_count' ..  '{' .. 'block="' .. rx_name .. '"} ' .. v .. '\n'
+        elseif k == 'Duplicate Count' then
+          output = output .. 'qsys_aes67_duplicate_count' ..  '{' .. 'block="' .. rx_name .. '"} ' .. v .. '\n'
+        elseif k == 'On Time' then
+          output = output .. 'qsys_aes67_ontime_count' ..  '{' .. 'block="' .. rx_name .. '"} ' .. v .. '\n'
+        elseif k == 'Too Late' then
+          output = output .. 'qsys_aes67_late_count' ..  '{' .. 'block="' .. rx_name .. '"} ' .. v .. '\n'
+        elseif k == 'PT Mismatch' then
+          output = output .. 'qsys_aes67_pt_mismatch_count' ..  '{' .. 'block="' .. rx_name .. '"} ' .. v .. '\n'
+        elseif k == 'Size Mismatch' then
+          output = output .. 'qsys_aes67_size_mismatch_count' ..  '{' .. 'block="' .. rx_name .. '"} ' .. v .. '\n'
+        end
+      end
+    end
+  
+    return output
+  end -- end GetStreamDetails
+  
   function CreateMetrics()
     local design = Design.GetStatus()
   
@@ -409,6 +445,28 @@ if Controls then
     body = body .. '# TYPE qsys_peripheral_status gauge\n'
     for k,v in pairs(Design.GetInventory()) do
       body = body .. 'qsys_peripheral_status{invDeviceModel="' .. v.Model .. '",invDeviceName="' .. v.Name .. '",invDeviceType="' .. v.Type .. '",invLocation="' .. v.Location .. '"} ' .. math.floor(v.Status.Code) .. '\n'
+    end
+  
+    -- include AES67 metrics for each Rx component in the design
+    if #RxComponents > 0 then
+      -- only include TYPE once even if there are many Rx components
+      body = body .. '# TYPE qsys_aes67_Enabled gauge\n'
+      body = body .. '# TYPE qsys_aes67_Connected_count gauge\n'
+      body = body .. '# TYPE qsys_aes67_DSCP gauge\n'
+      body = body .. '# TYPE qsys_aes67_count counter\n'
+      body = body .. '# TYPE qsys_aes67_accept_count counter\n'
+      body = body .. '# TYPE qsys_aes67_drop_count counter\n'
+      body = body .. '# TYPE qsys_aes67_missing_count counter\n'
+      body = body .. '# TYPE qsys_aes67_duplicate_count counter\n'
+      body = body .. '# TYPE qsys_aes67_ontime_count counter\n'
+      body = body .. '# TYPE qsys_aes67_late_count counter\n'
+      body = body .. '# TYPE qsys_aes67_pt_mismatch_count counter\n'
+      body = body .. '# TYPE qsys_aes67_size_mismatch_count counter\n'
+  
+      for _,rx_name in ipairs(RxComponents) do
+        local aes67_metrics = GetStreamDetails(rx_name)
+        body = body .. aes67_metrics
+      end
     end
   
     -- include custom metrics if enabled in Properties
@@ -567,6 +625,15 @@ if Controls then
     Controls['Status'].Value = 2
     Controls['Status'].String = 'Status component not found.  Did you enable script access?'
   end
+  
+  -- find all AES67 receivers in the design
+  RxComponents={}
+  for _,v in pairs(Components) do
+    if v.Type == 'input_box' then
+      table.insert(RxComponents,v.Name)
+    end
+  end
+  if DebugFunction then print('AES67 Receivers:', Dump(RxComponents)) end
   
   if Controls['Status'].Value == 0 then
     if DebugFunction then print(string.format('Listening on HTTP port %d', Controls.Port.Value)) end

--- a/runtime.lua
+++ b/runtime.lua
@@ -30,31 +30,11 @@ end
 
 function GetStreamDetails(rx_name)
   if DebugFunction then print("# Getting metrics from " .. rx_name) end
-  RX = Component.New(rx_name)
-  -- print(RX)
-  -- local controls = {}
-  -- for _,v in ipairs(Component.GetControls(RX)) do
-  --   controls[v.Name] = true
-  --   print(v.Name .. " = " .. RX[v.Name].String)
-  -- end
-
-  -- --print(Dump(controls))
-
-  local stream_name = RX['stream.name'].String
-  local stream_details = RX['stream.details'].String
-  local raw_sdp = RX['ds.raw.sdp'].String
-  local sdp_lan_a = RX['sdp.lan.a'].String
-  local sdp_lan_b = RX['sdp.lan.b'].String
-
-  --print(stream_name) 
-  --print(stream_details)
-  --print(raw_sdp)
-  --print(sdp_lan_a)
-  --print(sdp_lan_b)
+  local rx = Component.New(rx_name)
+  local stream_details = rx['stream.details'].String
 
   local output = ''
   for line in stream_details:gmatch("[^\r\n]+") do
-    --print(line)
     for k,v in line:gmatch("(.*): (.*)") do
       -- use the right type: gauge vs counter
       if k == 'Enabled' or k == 'Connected' or k == 'DSCP' then
@@ -204,7 +184,6 @@ function CreateMetrics()
 
     for _,rx_name in ipairs(RxComponents) do
       local aes67_metrics = GetStreamDetails(rx_name)
-
       body = body .. aes67_metrics
     end
   end

--- a/runtime.lua
+++ b/runtime.lua
@@ -28,6 +28,62 @@ function RemoveSocketFromTable(sock)
   end
 end
 
+function GetStreamDetails(rx_name)
+  if DebugFunction then print("# Getting metrics from " .. rx_name) end
+  RX = Component.New(rx_name)
+  -- print(RX)
+  -- local controls = {}
+  -- for _,v in ipairs(Component.GetControls(RX)) do
+  --   controls[v.Name] = true
+  --   print(v.Name .. " = " .. RX[v.Name].String)
+  -- end
+
+  -- --print(Dump(controls))
+
+  local stream_name = RX['stream.name'].String
+  local stream_details = RX['stream.details'].String
+  local raw_sdp = RX['ds.raw.sdp'].String
+  local sdp_lan_a = RX['sdp.lan.a'].String
+  local sdp_lan_b = RX['sdp.lan.b'].String
+
+  --print(stream_name) 
+  --print(stream_details)
+  --print(raw_sdp)
+  --print(sdp_lan_a)
+  --print(sdp_lan_b)
+
+  local output = ''
+  for line in stream_details:gmatch("[^\r\n]+") do
+    --print(line)
+    for k,v in line:gmatch("(.*): (.*)") do
+      -- use the right type: gauge vs counter
+      if k == 'Enabled' or k == 'Connected' or k == 'DSCP' then
+        output = output .. 'qsys_aes67_' .. k .. '{' .. 'block="' .. rx_name .. '"} ' .. v .. '\n'
+      elseif k == 'Count' then
+        output = output .. 'qsys_aes67_count' ..  '{' .. 'block="' .. rx_name .. '"} ' .. v .. '\n'
+      elseif k == 'Accept Count' then
+        output = output .. 'qsys_aes67_accept_count' ..  '{' .. 'block="' .. rx_name .. '"} ' .. v .. '\n'
+      elseif k == 'Drop Count' then
+        output = output .. 'qsys_aes67_drop_count' ..  '{' .. 'block="' .. rx_name .. '"} ' .. v .. '\n'
+      elseif k == 'Missing Count' then
+        output = output .. 'qsys_aes67_missing_count' ..  '{' .. 'block="' .. rx_name .. '"} ' .. v .. '\n'
+      elseif k == 'Duplicate Count' then
+        output = output .. 'qsys_aes67_duplicate_count' ..  '{' .. 'block="' .. rx_name .. '"} ' .. v .. '\n'
+      elseif k == 'On Time' then
+        output = output .. 'qsys_aes67_ontime_count' ..  '{' .. 'block="' .. rx_name .. '"} ' .. v .. '\n'
+      elseif k == 'Too Late' then
+        output = output .. 'qsys_aes67_late_count' ..  '{' .. 'block="' .. rx_name .. '"} ' .. v .. '\n'
+      elseif k == 'PT Mismatch' then
+        output = output .. 'qsys_aes67_pt_mismatch_count' ..  '{' .. 'block="' .. rx_name .. '"} ' .. v .. '\n'
+      elseif k == 'Size Mismatch' then
+        output = output .. 'qsys_aes67_size_mismatch_count' ..  '{' .. 'block="' .. rx_name .. '"} ' .. v .. '\n'
+      end
+    end
+  end
+
+  return output
+end -- end GetStreamDetails
+
 function CreateMetrics()
   local design = Design.GetStatus()
 
@@ -128,6 +184,29 @@ function CreateMetrics()
   body = body .. '# TYPE qsys_peripheral_status gauge\n'
   for k,v in pairs(Design.GetInventory()) do
     body = body .. 'qsys_peripheral_status{invDeviceModel="' .. v.Model .. '",invDeviceName="' .. v.Name .. '",invDeviceType="' .. v.Type .. '",invLocation="' .. v.Location .. '"} ' .. math.floor(v.Status.Code) .. '\n'
+  end
+
+  -- include AES67 metrics for each Rx component in the design
+  if #RxComponents > 0 then
+    -- only include TYPE once even if there are many Rx components
+    body = body .. '# TYPE qsys_aes67_Enabled gauge\n'
+    body = body .. '# TYPE qsys_aes67_Connected_count gauge\n'
+    body = body .. '# TYPE qsys_aes67_DSCP gauge\n'
+    body = body .. '# TYPE qsys_aes67_count counter\n'
+    body = body .. '# TYPE qsys_aes67_accept_count counter\n'
+    body = body .. '# TYPE qsys_aes67_drop_count counter\n'
+    body = body .. '# TYPE qsys_aes67_missing_count counter\n'
+    body = body .. '# TYPE qsys_aes67_duplicate_count counter\n'
+    body = body .. '# TYPE qsys_aes67_ontime_count counter\n'
+    body = body .. '# TYPE qsys_aes67_late_count counter\n'
+    body = body .. '# TYPE qsys_aes67_pt_mismatch_count counter\n'
+    body = body .. '# TYPE qsys_aes67_size_mismatch_count counter\n'
+
+    for _,rx_name in ipairs(RxComponents) do
+      local aes67_metrics = GetStreamDetails(rx_name)
+
+      body = body .. aes67_metrics
+    end
   end
 
   -- include custom metrics if enabled in Properties
@@ -286,6 +365,15 @@ else
   Controls['Status'].Value = 2
   Controls['Status'].String = 'Status component not found.  Did you enable script access?'
 end
+
+-- find all AES67 receivers in the design
+RxComponents={}
+for _,v in pairs(Components) do
+  if v.Type == 'input_box' then
+    table.insert(RxComponents,v.Name)
+  end
+end
+if DebugFunction then print('AES67 Receivers:', Dump(RxComponents)) end
 
 if Controls['Status'].Value == 0 then
   if DebugFunction then print(string.format('Listening on HTTP port %d', Controls.Port.Value)) end


### PR DESCRIPTION
Add packet counter metrics for all AES67 and Atmos receivers.  Tested only on 9.9.  Does not work with Dante receivers.